### PR TITLE
feat: add pause and unpause functions

### DIFF
--- a/src/Interfaces/ICertiva.cairo
+++ b/src/Interfaces/ICertiva.cairo
@@ -34,4 +34,7 @@ pub trait ICertiva<TContractState> {
         ref self: TContractState, certificate_id: felt252, hashed_key: ByteArray,
     ) -> bool;
     fn revoke_certificate(ref self: TContractState, certificate_id: felt252) -> Result<(), felt252>;
+    fn pause_contract(ref self: TContractState);
+    fn unpause_contract(ref self: TContractState);
+    fn check_if_paused(self: @TContractState) -> bool;
 }


### PR DESCRIPTION
### Description
This PR adds emergency control features for the cervita contract in the form of pause and unpause functions. 
It can only be used by the owner who acts as the admin 

## Features Added 

### Functions Added
- `pause_contract()` this allows the contract owner to halt all operations 
- `unpause_contract()`  this allows the contract owner to resume all operations 
- `check_if_paused()` - Public view function to check current pause status

- Access Control - Only the contract owner can pause and unpause operations
- State Protection - Prevents double-pausing with proper validation, throwing an error message
- Event Emission - Emits PausedContract event for tracking and Emits UnpauseContract event for tracking 





### Small modifications 
Internal function `assert_not_paused` to prevent functions from being run when they are paused
All critical functions now include pause checks:

- register_university()
- issue_certificate()
- bulk_issue_certificates()
- verify_certificate()
- revoke_certificate()


### Added Tests for Functions to cover all cases 
- test_pause_contract() - Basic pause functionality test
- test_pause_contract_as_non_admin() - Access control validation test
- test_pause_contract_should_panic_if_done_twice() - Double-pause prevention
- test_attempt_to_call_function_should_fail_after_contract_is_paused() - Function blocking after contract has been paused 
- test_unpause_contract() - Basic unpause functionality
- test_unpause_contract_as_non_owner() - Unpause access control test
- test_use_function_after_contract_has_been_unpaused() - State restoration for unpause 
- test_emmission_of_event_after_pausing() - Pause event emission
- test_emmission_of_event_after_unpausing() - Unpause event emission

All tests passing 
Closes #16 
please review @JayWebtech 

![image](https://github.com/user-attachments/assets/dd78fd6a-0eab-4bab-b538-172cc14eddf8)
