### PR TITLE
Implement contract upgradeability

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-scarb 2.11.2
+scarb 2.11.4
 starknet_foundry 0.38.3

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -2,6 +2,34 @@
 version = 1
 
 [[package]]
+name = "openzeppelin_access"
+version = "0.18.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:424314072ae27d5b6f4264472a5c403711448ea62763a661b89e6ff5f23297fd"
+dependencies = [
+ "openzeppelin_introspection",
+ "openzeppelin_utils",
+]
+
+[[package]]
+name = "openzeppelin_introspection"
+version = "0.18.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:46c4cc6c95c9baa4c7d5cc0ed2bdaf334f46c25a8c92b3012829fff936e3042b"
+
+[[package]]
+name = "openzeppelin_upgrades"
+version = "0.18.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:33c9d0865364fc18a5e7b471fe53c3b0f3e0aec56a94f435089638fad2a4a35b"
+
+[[package]]
+name = "openzeppelin_utils"
+version = "0.18.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:725b212839f3eddc32791408609099c5e808c167ca0cf331d8c1d778b07a4e21"
+
+[[package]]
 name = "snforge_scarb_plugin"
 version = "0.38.3"
 source = "registry+https://scarbs.xyz/"
@@ -20,5 +48,8 @@ dependencies = [
 name = "unichain_contracts"
 version = "0.1.0"
 dependencies = [
+ "openzeppelin_access",
+ "openzeppelin_upgrades",
+ "openzeppelin_utils",
  "snforge_std",
 ]

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -7,6 +7,9 @@ edition = "2024_07"
 
 [dependencies]
 starknet = "2.11.2"
+openzeppelin_access = "0.18.0"
+openzeppelin_upgrades = "0.18.0"
+openzeppelin_utils = "0.18.0"
 
 [dev-dependencies]
 snforge_std = "0.38.3"


### PR DESCRIPTION
## What does tthis PR do?

### Implement Upgradable Smart Contracts with Admin-Only Upgrade Functionality. closes #15

### IMPLEMENTATIONS
- [x] The smart contracts are upgradeable using a standard proxy pattern.

- [x] Only the admin is able to perform the upgrade.

- [x] Proper error handling and security checks are in place for upgrade authorization.

- [x] Documentation is updated to reflect the upgrade process and admin controls.

### Packages installed and imported
```
use openzeppelin_access::ownable::OwnableComponent;
use openzeppelin_upgrades::UpgradeableComponent;
use openzeppelin_upgrades::interface::IUpgradeable;
```
